### PR TITLE
Fixes #96, lsassy hanging indefinitely in NetExec

### DIFF
--- a/lsassy/dumpmethod/__init__.py
+++ b/lsassy/dumpmethod/__init__.py
@@ -289,6 +289,8 @@ class IDumpMethod:
                     first_execution = False
                     lsassy_logger.debug("Transformed command: {}".format(exec_command))
                     res = exec_method.exec(exec_command)
+                    lsassy_logger.debug("Cleaning up connection")
+                    exec_method.clean()
                     self.executor_clean()
                 self.clean()
             except Exception:

--- a/lsassy/exec/__init__.py
+++ b/lsassy/exec/__init__.py
@@ -22,3 +22,9 @@ class IExec:
             lsassy_logger.error("Module {} does not support Kerberos authentication".format(self.__module__))
             return False
         return True
+
+    def clean(self):
+        """
+        To be implemented in all exec modules
+        """
+        pass


### PR DESCRIPTION
This PR fixes the issue explained in #96, resulting in the lsassy module hanging in NetExec.
Therefore, now lsassy properly closes connections after executing a DumpMethod.